### PR TITLE
removed the `@walletconnect/web3-provider` from project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31840,8 +31840,7 @@
       }
     },
     "ethereumjs-abi": {
-      "version": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-      "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+      "version": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
       "optional": true,
       "peer": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "@typeform/embed-react": "^1.1.2",
-    "@walletconnect/web3-provider": "^1.6.5",
     "moralis": "^0.0.68",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6154,7 +6154,7 @@
     "setimmediate" "^1.0.5"
 
 "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
-  "resolved" "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0"
+  "resolved" "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz"
   "version" "0.6.8"
   dependencies:
     "bn.js" "^4.11.8"


### PR DESCRIPTION
This is to get rid of the ssh:// component of ethereumjs that doesn't work and runs a build error

"ethereumjs-abi": {
      "version": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
      "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",